### PR TITLE
Add photo carousel feature to Liquid templates

### DIFF
--- a/ZachsBlogTheme/Views/Content-Photos.liquid
+++ b/ZachsBlogTheme/Views/Content-Photos.liquid
@@ -1,0 +1,240 @@
+{% zone "Header" %}
+    <!-- Page Header -->
+    <header class="masthead" style="background-image: url('{{ "~/ZachsBlogTheme/img/post-bg.jpg" | href }}')">
+        <div class="overlay"></div>
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-8 col-md-10 mx-auto">
+                    <div class="page-heading">
+                        <h1>{{ Model.ContentItem.DisplayText }}</h1>
+                        <span class="subheading">Featured Photography</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+{% endzone %}
+
+<!-- Photo Carousel -->
+<div class="container">
+    <div class="row">
+        <div class="col-lg-10 col-md-12 mx-auto">            <div id="photo-carousel" class="carousel slide mb-5" data-ride="carousel">
+                <div class="carousel-indicators" id="carousel-indicators">
+                    <!-- Indicators will be populated by JavaScript -->
+                </div>
+                <div class="carousel-inner" id="carousel-inner">
+                    <!-- Carousel items will be populated by JavaScript -->
+                </div>
+                <a class="carousel-control-prev" href="#photo-carousel" role="button" data-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Previous</span>
+                </a>
+                <a class="carousel-control-next" href="#photo-carousel" role="button" data-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Next</span>
+                </a>
+            </div>
+              <!-- Loading indicator -->
+            <div id="loading-indicator" class="text-center mb-4">
+                <div class="spinner-border" role="status">
+                    <span class="sr-only">Loading photos...</span>
+                </div>
+                <p class="mt-2">Loading your featured photos...</p>
+            </div>
+            
+            <!-- Error message -->
+            <div id="error-message" class="alert alert-warning d-none">
+                <h4>No photos found</h4>
+                <p>We couldn't find any photos in your Featured Photos collection. Please make sure you have uploaded photos to the <code>/Featured-Photos/{{ "now" | date: "yyyy" }}/{{ "now" | date: "M" }}/</code> directory.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Regular page content -->
+{{ Model.Content.HtmlBodyPart | shape_render }}
+
+<!-- Photo Gallery Styles -->
+<style>
+.carousel-item img {
+    width: 100%;
+    height: 500px;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.carousel-caption {
+    background: rgba(0, 0, 0, 0.7);
+    border-radius: 8px;
+    padding: 15px;
+}
+
+.carousel-control-prev,
+.carousel-control-next {
+    filter: invert(1);
+}
+
+.carousel-indicators {
+    bottom: -50px;
+}
+
+.carousel-indicators [data-bs-target] {
+    background-color: #0085A1;
+}
+
+@media (max-width: 768px) {
+    .carousel-item img {
+        height: 300px;
+    }
+}
+</style>
+
+<!-- Photo Gallery JavaScript -->
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    loadFeaturedPhotos();
+});
+
+async function loadFeaturedPhotos() {
+    const currentYear = new Date().getFullYear();
+    const currentMonth = new Date().getMonth() + 1;
+    
+    // Try current month first, then fallback to previous months
+    const monthsToTry = [currentMonth];
+    if (currentMonth > 1) monthsToTry.push(currentMonth - 1);
+    if (currentMonth > 2) monthsToTry.push(currentMonth - 2);
+    
+    let photos = [];
+    let foundMonth = null;
+    
+    for (const month of monthsToTry) {
+        const folderPath = `Featured-Photos/${currentYear}/${month}`;
+        const monthPhotos = await getPhotosFromFolder(folderPath);
+        
+        if (monthPhotos.length > 0) {
+            photos = monthPhotos;
+            foundMonth = month;
+            break;
+        }
+    }
+    
+    // If still no photos and we're early in the year, try December of previous year
+    if (photos.length === 0 && currentMonth <= 3) {
+        const folderPath = `Featured-Photos/${currentYear - 1}/12`;
+        const yearEndPhotos = await getPhotosFromFolder(folderPath);
+        if (yearEndPhotos.length > 0) {
+            photos = yearEndPhotos;
+            foundMonth = 12;
+        }
+    }
+    
+    if (photos.length > 0) {
+        createCarousel(photos, foundMonth);
+        document.getElementById('loading-indicator').style.display = 'none';
+    } else {
+        document.getElementById('loading-indicator').style.display = 'none';
+        document.getElementById('error-message').classList.remove('d-none');
+    }
+}
+
+async function getPhotosFromFolder(folderPath) {
+    try {
+        // Common image file extensions
+        const extensions = ['jpg', 'jpeg', 'png', 'gif', 'webp', 'JPG', 'JPEG', 'PNG', 'GIF', 'WEBP'];
+        
+        // Common image naming patterns
+        const baseNames = [
+            // numbered files
+            ...Array.from({length: 20}, (_, i) => (i + 1).toString()),
+            ...Array.from({length: 20}, (_, i) => (i + 1).toString().padStart(2, '0')),
+            // common prefixes
+            ...Array.from({length: 10}, (_, i) => `img${i + 1}`),
+            ...Array.from({length: 10}, (_, i) => `image${i + 1}`),
+            ...Array.from({length: 10}, (_, i) => `photo${i + 1}`),
+            ...Array.from({length: 10}, (_, i) => `pic${i + 1}`),
+            // common names
+            'DSC', 'IMG', 'PHOTO', 'PIC'
+        ];
+        
+        const photos = [];
+        
+        // Try different naming patterns
+        for (const baseName of baseNames) {
+            for (const ext of extensions) {
+                const filename = `${baseName}.${ext}`;
+                const fullPath = `/media/${folderPath}/${filename}`;
+                
+                if (await imageExists(fullPath)) {
+                    photos.push({
+                        url: fullPath,
+                        filename: filename,
+                        caption: `Featured Photo - ${baseName}`
+                    });
+                    
+                    // Limit to 10 photos to prevent too many requests
+                    if (photos.length >= 10) break;
+                }
+            }
+            if (photos.length >= 10) break;
+        }
+        
+        return photos;
+    } catch (error) {
+        console.error('Error loading photos:', error);
+        return [];
+    }
+}
+
+function imageExists(url) {
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => resolve(true);
+        img.onerror = () => resolve(false);
+        img.src = url;
+        // Set a timeout to avoid hanging
+        setTimeout(() => resolve(false), 3000);
+    });
+}
+
+function createCarousel(photos, month) {
+    const carouselInner = document.getElementById('carousel-inner');
+    const carouselIndicators = document.getElementById('carousel-indicators');
+    
+    // Clear existing content
+    carouselInner.innerHTML = '';
+    carouselIndicators.innerHTML = '';
+    
+    // Create carousel items and indicators
+    photos.forEach((photo, index) => {
+        // Create carousel item
+        const carouselItem = document.createElement('div');
+        carouselItem.className = `carousel-item ${index === 0 ? 'active' : ''}`;
+        carouselItem.innerHTML = `
+            <img src="${photo.url}" class="d-block w-100" alt="${photo.caption}" loading="lazy">
+            <div class="carousel-caption d-none d-md-block">
+                <h5>${photo.caption}</h5>
+                <p>Featured Photos - ${new Date().getFullYear()}/${month}</p>
+            </div>
+        `;
+        carouselInner.appendChild(carouselItem);
+          // Create indicator
+        const indicator = document.createElement('button');
+        indicator.type = 'button';
+        indicator.setAttribute('data-target', '#photo-carousel');
+        indicator.setAttribute('data-slide-to', index.toString());
+        indicator.className = index === 0 ? 'active' : '';
+        indicator.setAttribute('aria-label', `Slide ${index + 1}`);
+        carouselIndicators.appendChild(indicator);
+    });
+      // Show the carousel
+    document.getElementById('photo-carousel').style.display = 'block';
+    
+    // Initialize Bootstrap 4 carousel
+    if (typeof $ !== 'undefined' && $.fn.carousel) {
+        $('#photo-carousel').carousel({
+            interval: 5000,
+            wrap: true
+        });
+    }
+}
+</script>

--- a/ZachsBlogTheme/Views/Content-PhotosSimple.liquid
+++ b/ZachsBlogTheme/Views/Content-PhotosSimple.liquid
@@ -1,0 +1,253 @@
+{% zone "Header" %}
+    <!-- Page Header -->
+    <header class="masthead" style="background-image: url('{{ "~/ZachsBlogTheme/img/post-bg.jpg" | href }}')">
+        <div class="overlay"></div>
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-8 col-md-10 mx-auto">
+                    <div class="page-heading">
+                        <h1>{{ Model.ContentItem.DisplayText }}</h1>
+                        <span class="subheading">Featured Photography</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+{% endzone %}
+
+<!-- Photo Carousel - Simple Version -->
+<div class="container">
+    <div class="row">
+        <div class="col-lg-10 col-md-12 mx-auto">
+            {% comment %}
+            <!-- Manual photo carousel - Replace these with your actual photo URLs -->
+            {% assign currentYear = "now" | date: "yyyy" %}
+            {% assign currentMonth = "now" | date: "M" %}
+            {% assign photoPath = "/media/Featured-Photos/" | append: currentYear | append: "/" | append: currentMonth | append: "/" %}
+            {% endcomment %}
+            
+            <div id="featuredPhotosCarousel" class="carousel slide mb-5" data-ride="carousel">
+                <ol class="carousel-indicators">
+                    <li data-target="#featuredPhotosCarousel" data-slide-to="0" class="active"></li>
+                    <li data-target="#featuredPhotosCarousel" data-slide-to="1"></li>
+                    <li data-target="#featuredPhotosCarousel" data-slide-to="2"></li>
+                    <li data-target="#featuredPhotosCarousel" data-slide-to="3"></li>
+                    <li data-target="#featuredPhotosCarousel" data-slide-to="4"></li>
+                </ol>
+                
+                <div class="carousel-inner">
+                    <!-- Photo 1 -->
+                    <div class="carousel-item active">
+                        <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/1.jpg" alt="Featured Photo 1" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                        <div class="photo-error" style="display:none;">
+                            <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/img1.jpg" alt="Featured Photo 1" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                            <div class="photo-error" style="display:none;">
+                                <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/photo1.jpg" alt="Featured Photo 1" onerror="handleImageError(this);">
+                            </div>
+                        </div>
+                        <div class="carousel-caption d-none d-md-block">
+                            <h5>Featured Photo</h5>
+                            <p>From our latest photography collection</p>
+                        </div>
+                    </div>
+
+                    <!-- Photo 2 -->
+                    <div class="carousel-item">
+                        <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/2.jpg" alt="Featured Photo 2" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                        <div class="photo-error" style="display:none;">
+                            <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/img2.jpg" alt="Featured Photo 2" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                            <div class="photo-error" style="display:none;">
+                                <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/photo2.jpg" alt="Featured Photo 2" onerror="handleImageError(this);">
+                            </div>
+                        </div>
+                        <div class="carousel-caption d-none d-md-block">
+                            <h5>Featured Photo</h5>
+                            <p>From our latest photography collection</p>
+                        </div>
+                    </div>
+
+                    <!-- Photo 3 -->
+                    <div class="carousel-item">
+                        <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/3.jpg" alt="Featured Photo 3" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                        <div class="photo-error" style="display:none;">
+                            <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/img3.jpg" alt="Featured Photo 3" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                            <div class="photo-error" style="display:none;">
+                                <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/photo3.jpg" alt="Featured Photo 3" onerror="handleImageError(this);">
+                            </div>
+                        </div>
+                        <div class="carousel-caption d-none d-md-block">
+                            <h5>Featured Photo</h5>
+                            <p>From our latest photography collection</p>
+                        </div>
+                    </div>
+
+                    <!-- Photo 4 -->
+                    <div class="carousel-item">
+                        <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/4.jpg" alt="Featured Photo 4" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                        <div class="photo-error" style="display:none;">
+                            <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/img4.jpg" alt="Featured Photo 4" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                            <div class="photo-error" style="display:none;">
+                                <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/photo4.jpg" alt="Featured Photo 4" onerror="handleImageError(this);">
+                            </div>
+                        </div>
+                        <div class="carousel-caption d-none d-md-block">
+                            <h5>Featured Photo</h5>
+                            <p>From our latest photography collection</p>
+                        </div>
+                    </div>
+
+                    <!-- Photo 5 -->
+                    <div class="carousel-item">
+                        <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/5.jpg" alt="Featured Photo 5" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                        <div class="photo-error" style="display:none;">
+                            <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/img5.jpg" alt="Featured Photo 5" onerror="this.style.display='none'; this.nextElementSibling.style.display='block';">
+                            <div class="photo-error" style="display:none;">
+                                <img class="d-block w-100 carousel-image" src="/media/Featured-Photos/2025/6/photo5.jpg" alt="Featured Photo 5" onerror="handleImageError(this);">
+                            </div>
+                        </div>
+                        <div class="carousel-caption d-none d-md-block">
+                            <h5>Featured Photo</h5>
+                            <p>From our latest photography collection</p>
+                        </div>
+                    </div>
+                </div>
+
+                <a class="carousel-control-prev" href="#featuredPhotosCarousel" role="button" data-slide="prev">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Previous</span>
+                </a>
+                <a class="carousel-control-next" href="#featuredPhotosCarousel" role="button" data-slide="next">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="sr-only">Next</span>
+                </a>
+            </div>
+
+            <!-- Fallback message -->
+            <div id="no-photos-message" class="alert alert-info text-center" style="display:none;">
+                <h4>Photo Gallery</h4>
+                <p>Welcome to our photo gallery! We're currently updating our featured photos.</p>
+                <p>Photos should be uploaded to: <code>/media/Featured-Photos/2025/6/</code></p>
+                <p>Supported file names: <code>1.jpg, 2.jpg, 3.jpg, img1.jpg, img2.jpg, photo1.jpg,</code> etc.</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Regular page content -->
+{{ Model.Content.HtmlBodyPart | shape_render }}
+
+<!-- Carousel Styles -->
+<style>
+.carousel-image {
+    height: 500px;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.carousel-caption {
+    background: rgba(0, 0, 0, 0.7);
+    border-radius: 8px;
+    padding: 15px;
+    bottom: 20px;
+}
+
+.carousel-control-prev,
+.carousel-control-next {
+    filter: invert(1);
+}
+
+.carousel-indicators {
+    bottom: -40px;
+}
+
+.carousel-indicators li {
+    background-color: #0085A1;
+}
+
+.carousel-indicators .active {
+    background-color: #005f73;
+}
+
+@media (max-width: 768px) {
+    .carousel-image {
+        height: 300px;
+    }
+    
+    .carousel-caption {
+        display: none !important;
+    }
+}
+
+/* Ensure carousel has proper spacing */
+.carousel {
+    margin-bottom: 2rem;
+}
+
+/* Style for photo errors */
+.photo-error {
+    padding: 2rem;
+    text-align: center;
+    background: #f8f9fa;
+    border-radius: 8px;
+    height: 500px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+</style>
+
+<!-- JavaScript for error handling -->
+<script>
+let visiblePhotos = 0;
+let totalPhotos = 5;
+
+function handleImageError(img) {
+    // Hide the current carousel item if all images failed
+    const carouselItem = img.closest('.carousel-item');
+    const indicator = document.querySelector(`[data-slide-to="${Array.from(carouselItem.parentElement.children).indexOf(carouselItem)}"]`);
+    
+    if (carouselItem && indicator) {
+        carouselItem.style.display = 'none';
+        indicator.style.display = 'none';
+    }
+    
+    checkVisiblePhotos();
+}
+
+function checkVisiblePhotos() {
+    const visibleItems = document.querySelectorAll('.carousel-item:not([style*="display: none"])');
+    
+    if (visibleItems.length === 0) {
+        document.getElementById('featuredPhotosCarousel').style.display = 'none';
+        document.getElementById('no-photos-message').style.display = 'block';
+    } else {
+        // Make sure the first visible item is active
+        document.querySelectorAll('.carousel-item').forEach(item => item.classList.remove('active'));
+        document.querySelectorAll('.carousel-indicators li').forEach(indicator => indicator.classList.remove('active'));
+        
+        if (visibleItems.length > 0) {
+            visibleItems[0].classList.add('active');
+            const firstVisibleIndex = Array.from(document.querySelectorAll('.carousel-item')).indexOf(visibleItems[0]);
+            const firstIndicator = document.querySelector(`[data-slide-to="${firstVisibleIndex}"]`);
+            if (firstIndicator) {
+                firstIndicator.classList.add('active');
+            }
+        }
+    }
+}
+
+// Check on page load
+document.addEventListener('DOMContentLoaded', function() {
+    // Give images time to load/fail
+    setTimeout(checkVisiblePhotos, 2000);
+    
+    // Initialize carousel
+    if (typeof $ !== 'undefined' && $.fn.carousel) {
+        $('#featuredPhotosCarousel').carousel({
+            interval: 5000,
+            pause: 'hover',
+            wrap: true
+        });
+    }
+});
+</script>


### PR DESCRIPTION
Introduce a new photo carousel in `Content-Photos.liquid` and `Content-PhotosSimple.liquid`. The carousel displays featured photography with a header, loading indicators, and error messages. The `Content-Photos.liquid` version dynamically loads images based on the current year and month, while the `Content-PhotosSimple.liquid` version uses hardcoded paths. Both versions include styling and error handling for missing images.